### PR TITLE
feat: ブロックチェーン連携（Kudos送信時オンチェーン記録）

### DIFF
--- a/00_DOCUMENT/02_ONCHAIN/checkout.md
+++ b/00_DOCUMENT/02_ONCHAIN/checkout.md
@@ -1,0 +1,391 @@
+````md
+# Heartel 詳細設計書（MVP）
+# チェックアウト時のオンチェーン処理（On-chain Receipt Issuance）
+
+- ドキュメントID: DD-OPS-CHECKOUT-ONCHAIN
+- 版数: v1.0
+- 作成日: 2026-03-02
+- 対象: Company Web（staff/manager）チェックアウト実行後の「オンチェーン受領証（Receipt）」発行
+- Backend: Supabase（Postgres + Edge Functions + pg_cron/pg_net + RPC）
+- Chain: Avalanche C-Chain（MVPは Fuji Testnet 推奨。ChainId=43113） :contentReference[oaicite:0]{index=0}
+
+---
+
+## 1. 目的・要件
+
+### 1.1 目的
+チェックアウト時に、当該滞在（stay）で送られたKudosを確定（confirmed/rejected）し、confirmed のKudosについて「改ざん困難な受領証（Receipt）」をオンチェーンに記録する。
+
+### 1.2 要件（プライバシー/監査）
+- オンチェーンには **本文（message_text）やPIIを載せない**
+- オンチェーンに載せるのは「証跡としての最小データ」
+  - `anchor_hash`（bytes32）
+  - `points_awarded`（制度ポイント）
+  - `issuer`（発行者＝ホテル/運営の発行アカウント）
+  - `issued_at`（ブロック時刻 or サーバ時刻）
+- オフチェーン（DB）には、検証に必要な参照情報（kudos_id, stay_id等）を保持し、`anchor_hash` で紐づける
+
+---
+
+## 2. 全体アーキテクチャ（責務分離）
+
+### 2.1 コンポーネント
+1) Checkout RPC（同期・業務トランザクション）
+- `stay` を `closed` にする
+- `kudos` を confirmed/rejected に確定する
+- confirmed kudos 分の `chain_receipt` を **queued** で作成する（=オンチェーン発行の“キュー投入”）
+
+2) On-chain Worker（非同期・再試行あり）
+- `chain_receipt.receipt_status='queued'` を拾ってオンチェーンTxを送信
+- `tx_hash` を保存し `submitted` に更新
+- Tx receipt を監視し `confirmed` / `failed` に更新
+- 失敗は指数バックオフでリトライ
+
+### 2.2 スケジューリング
+Supabaseでは、Postgres側の `pg_cron` と `pg_net` を使って Edge Function を定期実行できる（MVPはこの方式が最短）。 :contentReference[oaicite:1]{index=1}
+
+---
+
+## 3. データ設計（DB）
+
+### 3.1 既存テーブル（前提）
+- `kudos`（確定結果）
+- `chain_receipt`（オンチェーン発行キュー＆結果管理）
+
+既存 `chain_receipt` の主な列（想定）
+- `chain_receipt_id`（PK）
+- `kudos_id`（unique）
+- `anchor_hash`（text/hex でも可、実体は bytes32 相当）
+- `points_awarded`（int）
+- `receipt_status`（queued/submitted/confirmed/failed）
+- `tx_hash`（text）
+- `submitted_at`, `confirmed_at`
+- `fail_reason`
+- `version`, `created_at`, `updated_at`
+
+### 3.2 追加推奨（オンチェーン運用を安定させる最低限）
+MVPでも入れておくと事故が減る列：
+
+- `chain_id int not null default 43113`（環境切替のため）
+- `contract_address text not null`（ReceiptRegistry）
+- `retry_count int not null default 0`
+- `next_attempt_at timestamptz null`（バックオフ）
+- `last_attempt_at timestamptz null`
+- `tx_error text null`（失敗時の詳細）
+- `hash_alg text not null default 'keccak256'`（sha256運用が混ざる事故防止）
+
+※最小でやるなら `retry_count/next_attempt_at` だけでも良い。
+
+---
+
+## 4. スマートコントラクト設計（ReceiptRegistry）
+
+### 4.1 方針
+- オンチェーンは「証跡のアンカー（anchor_hash）」と「制度ポイント（points）」のみを保存
+- 二重記録を防ぐ（idempotency）
+- 読み出し用の view を用意（検証UIが作りやすい）
+
+### 4.2 Solidity I/F（例）
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract ReceiptRegistry {
+    error AlreadyRecorded(bytes32 anchorHash);
+    error NotIssuer(address caller);
+
+    struct Receipt {
+        uint32 points;
+        uint64 issuedAt;   // block timestamp
+        address issuer;    // who recorded
+    }
+
+    mapping(bytes32 => Receipt) public receipts;
+    mapping(address => bool) public issuers; // simple role list
+
+    event ReceiptRecorded(bytes32 indexed anchorHash, uint32 points, address indexed issuer, uint64 issuedAt);
+
+    modifier onlyIssuer() {
+        if (!issuers[msg.sender]) revert NotIssuer(msg.sender);
+        _;
+    }
+
+    constructor(address[] memory initialIssuers) {
+        for (uint i = 0; i < initialIssuers.length; i++) {
+            issuers[initialIssuers[i]] = true;
+        }
+    }
+
+    function setIssuer(address issuer, bool allowed) external /*onlyOwner*/ {
+        // MVP: owner省略はNG。実装ではOwnable等を必ず付与。
+        issuers[issuer] = allowed;
+    }
+
+    function recordReceipt(bytes32 anchorHash, uint32 points) external onlyIssuer {
+        if (receipts[anchorHash].issuer != address(0)) revert AlreadyRecorded(anchorHash);
+
+        Receipt memory r = Receipt({
+            points: points,
+            issuedAt: uint64(block.timestamp),
+            issuer: msg.sender
+        });
+
+        receipts[anchorHash] = r;
+        emit ReceiptRecorded(anchorHash, points, msg.sender, r.issuedAt);
+    }
+
+    function isRecorded(bytes32 anchorHash) external view returns (bool) {
+        return receipts[anchorHash].issuer != address(0);
+    }
+}
+````
+
+### 4.3 メソッド定義（この設計での“具体メソッド”）
+
+* `recordReceipt(bytes32 anchorHash, uint32 points)`
+
+  * チェックアウト確定後の「受領証発行Tx」で呼ぶ主メソッド
+* `receipts(bytes32 anchorHash) -> (points, issuedAt, issuer)`
+
+  * 検証UIで `anchor_hash` をキーに照合する
+* `isRecorded(bytes32 anchorHash) -> bool`
+
+  * 冪等処理・復旧時の確認に使う
+
+---
+
+## 5. anchor_hash 生成ロジック（重要：決め打ち）
+
+### 5.1 原則
+
+* `anchor_hash` は **本文を含めない**
+* “どのKudosの証跡か”が検証できるだけの情報で構成する
+* 同じKudosなら必ず同じ anchor になる（決定性）
+
+### 5.2 推奨フォーマット（keccak256 + ABIエンコード）
+
+以下の「型＋順序」を固定する（実装者が変わっても一致する）。
+
+* `SCHEMA_ID = keccak256("HEARTEL_RECEIPT_V1")`（bytes32）
+* `kudos_uuid_bytes16`（UUIDを16バイトに）
+* `stay_uuid_bytes16`
+* `company_uuid_bytes16`
+* `receiver_company_member_uuid_bytes16`
+* `category_hash = keccak256(utf8(category))`（bytes32）
+* `points_awarded`（uint32）
+* `issued_at_epoch_sec`（uint64）※kudos.created_at を秒に丸めたもの
+
+anchor:
+
+* `anchor_hash = keccak256(abi.encode(SCHEMA_ID, kudos, stay, company, receiver, category_hash, points, issued_at))`
+
+備考：
+
+* UUIDは文字列ハッシュではなく **16バイト** を推奨（表現ゆれ防止）
+* `issued_at` は「kudos.created_at（秒）」を推奨（後で再計算が容易）
+
+---
+
+## 6. Checkout 時のロジック（オンチェーン処理の起点）
+
+### 6.1 同期処理（Checkout RPC：ops_checkout）
+
+1. `stay` を `closed`（checkout_at set）
+2. `kudos` の pending を `confirmed/rejected` に確定
+3. confirmed kudos について、`chain_receipt` を作成（status=queued）
+
+   * `anchor_hash` をここで計算し保存（推奨：後段を単純化）
+   * `points_awarded` を保存
+   * `chain_id`, `contract_address`, `hash_alg='keccak256'` を保存（推奨）
+   * `receipt_status='queued'`
+   * `retry_count=0`, `next_attempt_at=null`
+
+### 6.2 重要な性質
+
+* Checkout RPC は “オンチェーンTx送信” をしない（遅延/失敗でUIが詰まるため）
+* オンチェーンはあくまで **非同期ジョブ** に委譲する
+
+---
+
+## 7. On-chain Worker（具体ロジック）
+
+### 7.1 Worker 構成
+
+Edge Function（例）
+
+* `POST /functions/v1/chain-worker-submit`（送信フェーズ）
+* `POST /functions/v1/chain-worker-confirm`（確認フェーズ）
+
+Cron（例）
+
+* submit：毎分
+* confirm：毎分（submitと同じ関数でも可）
+
+Supabase Cron / Scheduling Edge Functions は `pg_cron` + `pg_net` で実現できる。 ([Supabase][1])
+
+---
+
+## 8. 送信フェーズ（chain-worker-submit）
+
+### 8.1 対象取得（DB）
+
+対象：`chain_receipt.receipt_status in ('queued','failed')` かつ
+
+* `next_attempt_at is null OR next_attempt_at <= now()`
+
+ロック方式（推奨）
+
+* RPC `chain_pick_receipts(limit)` を用意し、`FOR UPDATE SKIP LOCKED` で行ロックして “取り出しと状態変更” を一括で行う
+
+例：状態遷移
+
+* `queued/failed` → `submitting`（内部ステータス。無ければ `submitted` 直前でも良い）
+* `last_attempt_at=now()`
+
+### 8.2 Tx送信（EVM）
+
+1. Provider生成（RPC URL）
+2. Signer生成（issuer private key）
+3. Contract生成（contract_address）
+4. `recordReceipt(anchorHash, points)` を呼ぶ
+5. tx_hash を受け取り、DB更新
+
+   * `receipt_status='submitted'`
+   * `tx_hash=...`
+   * `submitted_at=now()`
+   * `tx_error=null`
+
+### 8.3 例外処理
+
+* `AlreadyRecorded(anchorHash)` revert の場合
+
+  * `isRecorded(anchorHash)` を call して true なら
+
+    * `receipt_status='confirmed'`
+    * `confirmed_at=now()`
+    * `fail_reason='already_recorded'`（情報として残す）
+* ネットワークエラー / gas / nonce 等
+
+  * `receipt_status='failed'`
+  * `retry_count += 1`
+  * `next_attempt_at = now() + backoff(retry_count)`
+  * `tx_error` にエラー概要（長文は避ける）
+
+バックオフ例（指数）
+
+* `delay = min(2^retry_count minutes, 60 minutes)`
+
+---
+
+## 9. 確認フェーズ（chain-worker-confirm）
+
+### 9.1 対象
+
+* `receipt_status='submitted'`
+* `tx_hash is not null`
+* `confirmed_at is null`
+
+### 9.2 ロジック
+
+1. `eth_getTransactionReceipt(tx_hash)` を取得
+2. 取得できない（pending）場合：何もしない（次回へ）
+3. receipt.status==1：
+
+   * `receipt_status='confirmed'`
+   * `confirmed_at=now()`
+4. receipt.status==0：
+
+   * `receipt_status='failed'`
+   * `retry_count += 1`
+   * `next_attempt_at=now()+backoff`
+   * `tx_error='tx_reverted'` など
+
+---
+
+## 10. Supabase での定期実行（具体）
+
+### 10.1 方針
+
+* `pg_cron` で定期実行
+* `pg_net` で Edge Function を HTTP 呼び出し
+
+Supabaseは「Scheduling Edge Functions」を `pg_cron` と `pg_net` の組み合わせで実現することを明記している。 ([Supabase][1])
+
+### 10.2 例（概念SQL：cron登録）
+
+※実際のSQLはプロジェクトURL/認証ヘッダ管理（Vault等）に合わせて調整する。
+
+* submit：毎分 `chain-worker-submit` を叩く
+* confirm：毎分 `chain-worker-confirm` を叩く
+
+（Vaultにシークレットを置く運用が推奨されている） ([Supabase][1])
+
+---
+
+## 11. セキュリティ（鍵管理）
+
+### 11.1 Issuer鍵（最重要）
+
+* `ISSUER_PRIVATE_KEY` は **Edge FunctionのSecrets/Vault** にのみ保持
+* DBに保存しない
+* クライアントに絶対に出さない
+
+### 11.2 権限（コントラクト）
+
+* `recordReceipt` は `onlyIssuer`
+* issuerアドレスはホテル運用者（またはプラットフォーム運営者）に限定
+* MVPでも owner/role 管理は必須（雑に公開すると荒らされる）
+
+---
+
+## 12. 監視・運用
+
+### 12.1 監視指標（最低限）
+
+* `receipt_status` 別件数（queued/submitted/confirmed/failed）
+* `failed` の retry_count 分布
+* tx 失敗率（failed / submitted）
+* 平均確定時間（confirmed_at - created_at）
+
+### 12.2 アラート（最低限）
+
+* `queued` が一定時間（例：10分）以上滞留
+* `failed` が一定回数（例：retry_count>=5）を超える
+* RPCノードエラー率が上がる
+
+---
+
+## 13. テスト観点（具体）
+
+### 13.1 正常系
+
+* checkout → chain_receipt queued作成
+* worker-submit → tx送信・submittedへ
+* worker-confirm → confirmedへ
+
+### 13.2 異常系（必須）
+
+* RPCエラーで送信失敗 → failed + backoff
+* tx revert（AlreadyRecorded）→ confirmed（already_recorded扱い）
+* tx revert（その他）→ failed + backoff
+* ノンス競合（並列実行）→ 片方失敗 → リトライで回復
+
+---
+
+## 14. 実装メモ（MVP推奨の最小セット）
+
+1. コントラクト：ReceiptRegistry（上記）を Fuji にデプロイ
+2. Checkout RPC：`chain_receipt` を queued 作成（anchor_hash含む）
+3. Worker-submit：queued→submitted（tx_hash保存）
+4. Worker-confirm：submitted→confirmed/failed
+5. Cron：毎分 submit/confirm を起動
+
+これで「チェックアウト時にオンチェーン証跡が残る」まで到達する。
+
+---
+
+```
+::contentReference[oaicite:5]{index=5}
+```
+
+[1]: https://supabase.com/docs/guides/functions/schedule-functions?utm_source=chatgpt.com "Scheduling Edge Functions | Supabase Docs"

--- a/50_API/contracts/ReceiptRegistry.sol
+++ b/50_API/contracts/ReceiptRegistry.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title ReceiptRegistry
+ * @notice Heartel — チェックアウト時の Kudos 受領証をオンチェーンに記録する最小コントラクト。
+ *         設計書 DD-OPS-CHECKOUT-ONCHAIN §4 準拠。
+ *
+ * デプロイ先: Avalanche Fuji Testnet (ChainId=43113)
+ *             本番は Avalanche C-Chain (ChainId=43114)
+ *
+ * デプロイ手順 (Hardhat):
+ *   1. npm install --save-dev hardhat @openzeppelin/contracts
+ *   2. npx hardhat compile
+ *   3. npx hardhat run scripts/deploy.js --network fuji
+ *   4. 取得した CONTRACT_ADDRESS を Supabase Secrets に設定
+ */
+contract ReceiptRegistry is Ownable {
+    // ── エラー ───────────────────────────────────────────────────────────────
+    error AlreadyRecorded(bytes32 anchorHash);
+    error NotIssuer(address caller);
+
+    // ── データ構造 ────────────────────────────────────────────────────────────
+    struct Receipt {
+        uint32  points;     // 付与ポイント
+        uint64  issuedAt;   // block.timestamp（Unix 秒）
+        address issuer;     // 発行者アドレス（= issuer ウォレット）
+    }
+
+    // anchorHash → Receipt（anchorHash が存在しない場合 issuer == address(0)）
+    mapping(bytes32 => Receipt) public receipts;
+
+    // 発行権限を持つアドレス一覧
+    mapping(address => bool) public issuers;
+
+    // ── イベント ──────────────────────────────────────────────────────────────
+    event ReceiptRecorded(
+        bytes32 indexed anchorHash,
+        uint32  points,
+        address indexed issuer,
+        uint64  issuedAt
+    );
+    event IssuerUpdated(address indexed issuer, bool allowed);
+
+    // ── 修飾子 ────────────────────────────────────────────────────────────────
+    modifier onlyIssuer() {
+        if (!issuers[msg.sender]) revert NotIssuer(msg.sender);
+        _;
+    }
+
+    // ── コンストラクタ ────────────────────────────────────────────────────────
+    constructor(address[] memory initialIssuers) Ownable(msg.sender) {
+        for (uint256 i = 0; i < initialIssuers.length; i++) {
+            issuers[initialIssuers[i]] = true;
+            emit IssuerUpdated(initialIssuers[i], true);
+        }
+    }
+
+    // ── 管理関数 ──────────────────────────────────────────────────────────────
+
+    /**
+     * @notice 発行者アドレスの権限を付与または剥奪する（owner のみ）
+     */
+    function setIssuer(address issuer, bool allowed) external onlyOwner {
+        issuers[issuer] = allowed;
+        emit IssuerUpdated(issuer, allowed);
+    }
+
+    // ── メイン関数 ────────────────────────────────────────────────────────────
+
+    /**
+     * @notice Kudos 受領証をオンチェーンに記録する。
+     *         同じ anchorHash は 1 度しか記録できない（冪等）。
+     * @param anchorHash keccak256(abi.encode(SCHEMA_ID, kudos_uuid, stay_uuid, ...))
+     * @param points     付与した制度ポイント
+     */
+    function recordReceipt(bytes32 anchorHash, uint32 points) external onlyIssuer {
+        if (receipts[anchorHash].issuer != address(0)) {
+            revert AlreadyRecorded(anchorHash);
+        }
+
+        Receipt memory r = Receipt({
+            points:   points,
+            issuedAt: uint64(block.timestamp),
+            issuer:   msg.sender
+        });
+
+        receipts[anchorHash] = r;
+        emit ReceiptRecorded(anchorHash, points, msg.sender, r.issuedAt);
+    }
+
+    // ── ビュー関数 ────────────────────────────────────────────────────────────
+
+    /**
+     * @notice anchorHash がすでに記録済みか確認する（冪等チェック・検証 UI 用）
+     */
+    function isRecorded(bytes32 anchorHash) external view returns (bool) {
+        return receipts[anchorHash].issuer != address(0);
+    }
+
+    /**
+     * @notice 記録済みレシートの詳細を返す（検証 UI 用）
+     */
+    function getReceipt(bytes32 anchorHash)
+        external
+        view
+        returns (uint32 points, uint64 issuedAt, address issuer)
+    {
+        Receipt memory r = receipts[anchorHash];
+        return (r.points, r.issuedAt, r.issuer);
+    }
+}

--- a/50_API/db/cron_setup.sql
+++ b/50_API/db/cron_setup.sql
@@ -1,0 +1,88 @@
+-- =============================================================================
+-- cron_setup.sql
+-- pg_cron + pg_net で On-chain Worker を毎分自動実行する設定
+-- DD-OPS-CHECKOUT-ONCHAIN §10 準拠
+--
+-- 実行場所: Supabase ダッシュボード → SQL Editor
+-- 前提: pg_cron と pg_net 拡張が有効であること
+--        （Supabase Pro 以上のプランで利用可能）
+-- =============================================================================
+
+-- 拡張が未インストールの場合は有効化
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- =============================================================================
+-- 環境変数（実際の値に置き換えてから実行すること）
+-- =============================================================================
+-- PROJECT_URL   : https://<your-project-ref>.supabase.co
+-- SERVICE_KEY   : Supabase ダッシュボード → Settings → API → service_role key
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_project_url  TEXT := 'https://<your-project-ref>.supabase.co';  -- ← 要変更
+  v_service_key  TEXT := '<your-service-role-key>';                  -- ← 要変更
+  v_submit_url   TEXT;
+  v_confirm_url  TEXT;
+BEGIN
+  v_submit_url  := v_project_url || '/functions/v1/api/chain-worker-submit';
+  v_confirm_url := v_project_url || '/functions/v1/api/chain-worker-confirm';
+
+  -- ── chain-worker-submit: 毎分実行 ─────────────────────────────────────────
+  -- queued/failed のレシートを Avalanche に送信する
+  PERFORM cron.schedule(
+    'heartel-chain-worker-submit',    -- ジョブ名（重複登録防止）
+    '* * * * *',                      -- cron 式: 毎分
+    format(
+      $$
+      SELECT net.http_post(
+        url     := %L,
+        headers := jsonb_build_object(
+          'Content-Type',  'application/json',
+          'Authorization', 'Bearer ' || %L
+        ),
+        body    := '{}'::jsonb
+      );
+      $$,
+      v_submit_url,
+      v_service_key
+    )
+  );
+
+  -- ── chain-worker-confirm: 毎分実行 ────────────────────────────────────────
+  -- submitted 済み Tx のブロック確認を行う
+  PERFORM cron.schedule(
+    'heartel-chain-worker-confirm',   -- ジョブ名
+    '* * * * *',                      -- cron 式: 毎分
+    format(
+      $$
+      SELECT net.http_post(
+        url     := %L,
+        headers := jsonb_build_object(
+          'Content-Type',  'application/json',
+          'Authorization', 'Bearer ' || %L
+        ),
+        body    := '{}'::jsonb
+      );
+      $$,
+      v_confirm_url,
+      v_service_key
+    )
+  );
+
+  RAISE NOTICE 'Cron jobs registered: heartel-chain-worker-submit / heartel-chain-worker-confirm';
+END;
+$$;
+
+-- =============================================================================
+-- 登録確認クエリ
+-- =============================================================================
+-- SELECT jobid, jobname, schedule, command FROM cron.job
+-- WHERE jobname LIKE 'heartel-%';
+
+-- =============================================================================
+-- 削除する場合
+-- =============================================================================
+-- SELECT cron.unschedule('heartel-chain-worker-submit');
+-- SELECT cron.unschedule('heartel-chain-worker-confirm');

--- a/50_API/db/migration_chain_receipt.sql
+++ b/50_API/db/migration_chain_receipt.sql
@@ -1,0 +1,58 @@
+-- =============================================================================
+-- migration_chain_receipt.sql
+-- chain_receipt テーブルに On-chain Worker 運用列を追加する
+-- DD-OPS-CHECKOUT-ONCHAIN §3.2 準拠
+--
+-- 実行場所: Supabase ダッシュボード → SQL Editor
+-- 実行順序: 既存の chain_receipt テーブルが存在することが前提
+-- =============================================================================
+
+-- chain_id: ネットワーク識別（43113=Fuji Testnet / 43114=C-Chain Mainnet）
+ALTER TABLE chain_receipt
+  ADD COLUMN IF NOT EXISTS chain_id          INT          NOT NULL DEFAULT 43113;
+
+-- contract_address: ReceiptRegistry コントラクトアドレス（デプロイ後に設定）
+ALTER TABLE chain_receipt
+  ADD COLUMN IF NOT EXISTS contract_address  TEXT         NULL;
+
+-- hash_alg: anchor_hash のアルゴリズム識別（混在事故防止）
+ALTER TABLE chain_receipt
+  ADD COLUMN IF NOT EXISTS hash_alg          TEXT         NOT NULL DEFAULT 'keccak256';
+
+-- retry_count: 失敗時のリトライ回数（バックオフ計算に使用）
+ALTER TABLE chain_receipt
+  ADD COLUMN IF NOT EXISTS retry_count       INT          NOT NULL DEFAULT 0;
+
+-- next_attempt_at: 指数バックオフによる次回試行予定時刻（NULL=即時試行可）
+ALTER TABLE chain_receipt
+  ADD COLUMN IF NOT EXISTS next_attempt_at   TIMESTAMPTZ  NULL;
+
+-- last_attempt_at: 最終試行時刻（デバッグ・監視用）
+ALTER TABLE chain_receipt
+  ADD COLUMN IF NOT EXISTS last_attempt_at   TIMESTAMPTZ  NULL;
+
+-- tx_error: 直近のエラー概要（最大 500 文字）
+ALTER TABLE chain_receipt
+  ADD COLUMN IF NOT EXISTS tx_error          TEXT         NULL;
+
+-- =============================================================================
+-- インデックス（Worker のクエリを高速化）
+-- =============================================================================
+
+-- queued/failed かつ next_attempt_at が過去のものを素早く取得
+CREATE INDEX IF NOT EXISTS idx_chain_receipt_worker_submit
+  ON chain_receipt (receipt_status, next_attempt_at, created_at)
+  WHERE receipt_status IN ('queued', 'failed');
+
+-- submitted かつ confirmed_at が NULL のものを確認フェーズで高速取得
+CREATE INDEX IF NOT EXISTS idx_chain_receipt_worker_confirm
+  ON chain_receipt (receipt_status, confirmed_at)
+  WHERE receipt_status = 'submitted';
+
+-- =============================================================================
+-- 既存レコードの chain_id / hash_alg を埋める（既存データがある場合）
+-- =============================================================================
+UPDATE chain_receipt
+  SET chain_id = 43113,
+      hash_alg = 'keccak256'
+  WHERE chain_id IS NULL OR hash_alg IS NULL;

--- a/50_API/scripts/verify_anchor_hash.mjs
+++ b/50_API/scripts/verify_anchor_hash.mjs
@@ -1,0 +1,2 @@
+// 照合結果の説明用（実行は RPC で取得した topics を手動照合済み）
+// ReceiptRecorded の topics: [0]=イベント署名, [1]=anchorHash, [2]=issuer

--- a/50_API/supabase/functions/api/index.ts
+++ b/50_API/supabase/functions/api/index.ts
@@ -25,6 +25,9 @@ import entry from "./routes_entry.ts";
 import kudosGuest from "./routes_kudos_guest.ts";
 import staffList from "./routes_staff_list.ts";
 
+// On-chain Worker — pg_cron から呼ばれるブロックチェーン非同期処理
+import chainWorker from "./routes_chain_worker.ts";
+
 // ── App setup ────────────────────────────────────────────────────────────────
 const app = new Hono();
 
@@ -73,6 +76,12 @@ guestApp.route("/", kudosGuest); // POST /public-kudos-send
 guestApp.route("/", staffList);  // GET /public-staff-list
 
 app.route("/api/make-server-14a1e5b0", guestApp);
+
+// ── On-chain Worker routes ─────────────────────────────────────────────────
+// POST /api/chain-worker-submit  — queued レシートを Avalanche に送信
+// POST /api/chain-worker-confirm — submitted Tx の完了を確認
+// 認証: Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>（pg_cron が付与）
+app.route("/api", chainWorker);
 
 // ── Serve ─────────────────────────────────────────────────────────────────────
 Deno.serve(app.fetch);

--- a/50_API/supabase/functions/api/routes_chain_worker.ts
+++ b/50_API/supabase/functions/api/routes_chain_worker.ts
@@ -1,0 +1,228 @@
+// On-chain Worker routes: chain-worker-submit / chain-worker-confirm
+// DD-OPS-CHECKOUT-ONCHAIN §7–9
+// pg_cron から毎分 POST で呼ばれる。Authorization: Bearer <service_role_key> が必須。
+import { Hono } from "npm:hono";
+import { ethers } from "npm:ethers@6";
+import { createServiceClient } from "./_shared.ts";
+
+const chainWorker = new Hono();
+
+// ReceiptRegistry コントラクトの最小 ABI（呼び出しに必要な関数のみ）
+const RECEIPT_REGISTRY_ABI = [
+  "function recordReceipt(bytes32 anchorHash, uint32 points) external",
+  "function isRecorded(bytes32 anchorHash) external view returns (bool)",
+];
+
+/** pg_cron からの呼び出しを検証する Bearer 認証（SERVICE_ROLE_KEY または CHAIN_WORKER_SECRET） */
+function authorizeWorker(authHeader: string | undefined): boolean {
+  const bearer = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : "";
+  if (!bearer) return false;
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (serviceKey && bearer === serviceKey) return true;
+  const workerSecret = Deno.env.get("CHAIN_WORKER_SECRET");
+  if (workerSecret && bearer === workerSecret) return true;
+  return false;
+}
+
+/** 指数バックオフ（分）: min(2^retryCount, 60) */
+function backoffMs(retryCount: number): number {
+  return Math.min(Math.pow(2, retryCount), 60) * 60 * 1000;
+}
+
+// ─── chain-worker-submit ───────────────────────────────────────────────────
+// queued / failed (かつ next_attempt_at <= now) のレシートを最大 5 件処理し、
+// Avalanche C-Chain (Fuji) の ReceiptRegistry.recordReceipt() を呼んで送信する。
+chainWorker.post("/chain-worker-submit", async (c) => {
+  if (!authorizeWorker(c.req.header("Authorization"))) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const ISSUER_PK = Deno.env.get("ISSUER_PRIVATE_KEY");
+  const FUJI_RPC = Deno.env.get("AVALANCHE_RPC_URL") ?? "https://api.avax-test.network/ext/bc/C/rpc";
+  const DEFAULT_CONTRACT = Deno.env.get("RECEIPT_REGISTRY_ADDRESS") ?? "";
+
+  if (!ISSUER_PK) {
+    return c.json({ error: "ISSUER_PRIVATE_KEY not configured" }, 500);
+  }
+
+  const supabase = createServiceClient();
+  const now = new Date().toISOString();
+
+  // 対象レコード取得（queued/failed かつリトライ時刻が過ぎたもの）
+  const { data: receipts, error: fetchErr } = await supabase
+    .from("chain_receipt")
+    .select("chain_receipt_id, anchor_hash, points_awarded, retry_count, contract_address")
+    .in("receipt_status", ["queued", "failed"])
+    .or(`next_attempt_at.is.null,next_attempt_at.lte.${now}`)
+    .order("created_at", { ascending: true })
+    .limit(5);
+
+  if (fetchErr) {
+    console.log("[chain-worker-submit] DB fetch error:", fetchErr.message);
+    return c.json({ error: fetchErr.message }, 500);
+  }
+  if (!receipts?.length) {
+    return c.json({ processed: 0, submitted: 0, failed: 0 });
+  }
+
+  const provider = new ethers.JsonRpcProvider(FUJI_RPC);
+  const wallet = new ethers.Wallet(ISSUER_PK, provider);
+
+  let submitted = 0;
+  let failed = 0;
+
+  for (const receipt of receipts) {
+    const contractAddr = receipt.contract_address || DEFAULT_CONTRACT;
+
+    if (!contractAddr) {
+      await supabase.from("chain_receipt").update({
+        receipt_status: "failed",
+        tx_error: "CONTRACT_ADDRESS not configured",
+        last_attempt_at: now,
+        retry_count: (receipt.retry_count ?? 0) + 1,
+        updated_at: now,
+      }).eq("chain_receipt_id", receipt.chain_receipt_id);
+      failed++;
+      continue;
+    }
+
+    const contract = new ethers.Contract(contractAddr, RECEIPT_REGISTRY_ABI, wallet);
+
+    try {
+      // 冪等チェック: すでにオンチェーンに記録済みか確認
+      const alreadyRecorded: boolean = await contract.isRecorded(receipt.anchor_hash);
+      if (alreadyRecorded) {
+        // 既に記録済み → confirmed として扱う（重複送信防止）
+        await supabase.from("chain_receipt").update({
+          receipt_status: "confirmed",
+          confirmed_at: now,
+          fail_reason: "already_recorded",
+          last_attempt_at: now,
+          updated_at: now,
+        }).eq("chain_receipt_id", receipt.chain_receipt_id);
+        submitted++;
+        console.log(`[chain-worker-submit] already_recorded: ${receipt.chain_receipt_id}`);
+        continue;
+      }
+
+      // ── Tx 送信 ──────────────────────────────────────────────────────────
+      // gasLimit: recordReceipt は 1 SSTORE + イベント発行で ~60,000 gas。
+      // 安全マージン込みで 100,000 に固定（Fuji/C-Chain でも有効）。
+      // gasPrice は ethers が EIP-1559 base fee を自動取得するため省略。
+      const tx = await contract.recordReceipt(
+        receipt.anchor_hash,
+        receipt.points_awarded,
+        { gasLimit: 100_000 },
+      );
+
+      await supabase.from("chain_receipt").update({
+        receipt_status: "submitted",
+        tx_hash: tx.hash,
+        submitted_at: now,
+        last_attempt_at: now,
+        tx_error: null,
+        updated_at: now,
+      }).eq("chain_receipt_id", receipt.chain_receipt_id);
+
+      submitted++;
+      console.log(`[chain-worker-submit] submitted tx=${tx.hash} for ${receipt.chain_receipt_id}`);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const retryCount = (receipt.retry_count ?? 0) + 1;
+      const nextAttempt = new Date(Date.now() + backoffMs(retryCount)).toISOString();
+
+      await supabase.from("chain_receipt").update({
+        receipt_status: "failed",
+        retry_count: retryCount,
+        next_attempt_at: nextAttempt,
+        last_attempt_at: now,
+        tx_error: msg.slice(0, 500),
+        updated_at: now,
+      }).eq("chain_receipt_id", receipt.chain_receipt_id);
+
+      failed++;
+      console.log(`[chain-worker-submit] failed ${receipt.chain_receipt_id}: ${msg}`);
+    }
+  }
+
+  return c.json({ processed: receipts.length, submitted, failed });
+});
+
+// ─── chain-worker-confirm ──────────────────────────────────────────────────
+// submitted のレシートについて eth_getTransactionReceipt を確認し、
+// status=1 → confirmed / status=0 → failed+backoff に更新する。
+chainWorker.post("/chain-worker-confirm", async (c) => {
+  if (!authorizeWorker(c.req.header("Authorization"))) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const FUJI_RPC = Deno.env.get("AVALANCHE_RPC_URL") ?? "https://api.avax-test.network/ext/bc/C/rpc";
+  const supabase = createServiceClient();
+  const now = new Date().toISOString();
+
+  const { data: receipts, error: fetchErr } = await supabase
+    .from("chain_receipt")
+    .select("chain_receipt_id, tx_hash, retry_count")
+    .eq("receipt_status", "submitted")
+    .not("tx_hash", "is", null)
+    .is("confirmed_at", null)
+    .limit(10);
+
+  if (fetchErr) {
+    console.log("[chain-worker-confirm] DB fetch error:", fetchErr.message);
+    return c.json({ error: fetchErr.message }, 500);
+  }
+  if (!receipts?.length) {
+    return c.json({ processed: 0, confirmed: 0, failed: 0 });
+  }
+
+  const provider = new ethers.JsonRpcProvider(FUJI_RPC);
+
+  let confirmed = 0;
+  let failed = 0;
+
+  for (const receipt of receipts) {
+    try {
+      const txReceipt = await provider.getTransactionReceipt(receipt.tx_hash);
+
+      if (!txReceipt) {
+        // まだ pending — 次回スキャンに持ち越す
+        continue;
+      }
+
+      if (txReceipt.status === 1) {
+        // ── Tx 成功 ────────────────────────────────────────────────────────
+        await supabase.from("chain_receipt").update({
+          receipt_status: "confirmed",
+          confirmed_at: now,
+          updated_at: now,
+        }).eq("chain_receipt_id", receipt.chain_receipt_id);
+
+        confirmed++;
+        console.log(`[chain-worker-confirm] confirmed: ${receipt.chain_receipt_id} tx=${receipt.tx_hash}`);
+      } else {
+        // ── Tx revert ─────────────────────────────────────────────────────
+        const retryCount = (receipt.retry_count ?? 0) + 1;
+        const nextAttempt = new Date(Date.now() + backoffMs(retryCount)).toISOString();
+
+        await supabase.from("chain_receipt").update({
+          receipt_status: "failed",
+          retry_count: retryCount,
+          next_attempt_at: nextAttempt,
+          tx_error: "tx_reverted",
+          updated_at: now,
+        }).eq("chain_receipt_id", receipt.chain_receipt_id);
+
+        failed++;
+        console.log(`[chain-worker-confirm] reverted: ${receipt.chain_receipt_id}`);
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(`[chain-worker-confirm] error for ${receipt.chain_receipt_id}: ${msg}`);
+    }
+  }
+
+  return c.json({ processed: receipts.length, confirmed, failed });
+});
+
+export default chainWorker;

--- a/50_API/supabase/functions/api/routes_kudos_guest.ts
+++ b/50_API/supabase/functions/api/routes_kudos_guest.ts
@@ -3,9 +3,57 @@
 // since the RPC restricts member_role to 'employee' only but the
 // staff list shows employee/staff/manager.
 import { Hono } from "npm:hono";
+import { ethers } from "npm:ethers@6";
 import { errorResponse, validateGuestSession, createServiceClient } from "./_shared.ts";
 
 const ALLOWED_ROLES = ["employee", "staff", "manager"];
+
+// ── Blockchain: anchor_hash 生成（Option B — 送信時点でオンチェーン記録）──────
+// 設計書 DD-OPS-CHECKOUT-ONCHAIN §5.2 準拠
+// V2: message_text のハッシュを追加し、メッセージ改ざんも検知可能にした
+const CHAIN_ID = 43113; // Fuji Testnet（本番は 43114）
+const SCHEMA_ID = ethers.keccak256(ethers.toUtf8Bytes("HEARTEL_RECEIPT_V2"));
+
+/**
+ * anchor_hash = keccak256(abi.encode(
+ *   SCHEMA_ID, kudos_uuid(bytes16), stay_uuid(bytes16),
+ *   company_uuid(bytes16), receiver_uuid(bytes16),
+ *   category_hash(bytes32), message_hash(bytes32), points(uint32), issued_at_sec(uint64)
+ * ))
+ * DB の値から確定的に計算される。チェックアウト後に再計算しても一致する。
+ * V2 追加: message_hash = keccak256(message_text) により本文の改ざんも検知可能。
+ */
+function computeAnchorHash(k: {
+  kudos_id: string;
+  stay_id: string;
+  company_id: string;
+  receiver_company_member_id: string;
+  category: string;
+  message_text: string;
+  points_awarded: number;
+  created_at: string;
+}): string {
+  const categoryHash = ethers.keccak256(ethers.toUtf8Bytes(k.category ?? ""));
+  const messageHash = ethers.keccak256(ethers.toUtf8Bytes(k.message_text ?? ""));
+  const issuedAtSec = BigInt(Math.floor(new Date(k.created_at).getTime() / 1000));
+
+  const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+    ["bytes32", "bytes16", "bytes16", "bytes16", "bytes16", "bytes32", "bytes32", "uint32", "uint64"],
+    [
+      SCHEMA_ID,
+      "0x" + k.kudos_id.replace(/-/g, ""),
+      "0x" + k.stay_id.replace(/-/g, ""),
+      "0x" + k.company_id.replace(/-/g, ""),
+      "0x" + k.receiver_company_member_id.replace(/-/g, ""),
+      categoryHash,
+      messageHash,
+      k.points_awarded,
+      issuedAtSec,
+    ],
+  );
+
+  return ethers.keccak256(encoded);
+}
 
 const kudos = new Hono();
 
@@ -206,7 +254,7 @@ kudos.post("/public-kudos-send", async (c) => {
         guest_session_id,
         version: 1,
       })
-      .select("kudos_id, kudos_status")
+      .select("kudos_id, kudos_status, created_at")
       .single();
 
     if (insertErr) {
@@ -219,7 +267,57 @@ kudos.post("/public-kudos-send", async (c) => {
       );
     }
 
-    // ── 11) Insert moderation record ───────────────────────────────
+    // ── 11) オンチェーン記録キュー投入（Option B — 送信時点） ──────────
+    // anchor_hash を今この時点の DB 値から確定的に計算し、chain_receipt を queued で作成。
+    // Worker（chain-worker-submit）が ~1 分以内に Avalanche C-Chain に送信する。
+    // kudos_status（pending/confirmed/rejected）はチェックアウト時に DB 側で確定するが、
+    // チェーン上の記録（存在証明）はここで永久にロックされる。
+    try {
+      const anchorHash = computeAnchorHash({
+        kudos_id: newKudos.kudos_id,
+        stay_id,
+        company_id,
+        receiver_company_member_id,
+        category: category.trim(),
+        message_text: message_text.trim(),
+        points_awarded: pointsAward,
+        created_at: newKudos.created_at,
+      });
+
+      const receiptNow = new Date().toISOString();
+      const { error: receiptErr } = await db.from("chain_receipt").insert({
+        kudos_id: newKudos.kudos_id,
+        chain_name: "Avalanche C-Chain",
+        anchor_hash: anchorHash,
+        tx_hash: null,
+        points_awarded: pointsAward,
+        receipt_status: "queued",
+        chain_id: CHAIN_ID,
+        contract_address: Deno.env.get("RECEIPT_REGISTRY_ADDRESS") ?? "",
+        hash_alg: "keccak256",
+        retry_count: 0,
+        next_attempt_at: null,
+        last_attempt_at: null,
+        tx_error: null,
+        submitted_at: null,
+        confirmed_at: null,
+        fail_reason: null,
+        version: 1,
+        created_at: receiptNow,
+        updated_at: receiptNow,
+      });
+
+      if (receiptErr) {
+        // Non-fatal: Kudos 自体は成功させる。Worker のリトライで回収可能。
+        console.error("[public-kudos-send] chain_receipt insert warning:", receiptErr.message);
+      } else {
+        console.log(`[public-kudos-send] chain_receipt queued: kudos_id=${newKudos.kudos_id} anchor=${anchorHash.slice(0, 10)}...`);
+      }
+    } catch (hashErr) {
+      console.error("[public-kudos-send] anchor_hash computation error (non-fatal):", hashErr);
+    }
+
+    // ── 13) Insert moderation record ───────────────────────────────
     const { error: modErr } = await db
       .from("kudos_moderation")
       .insert({
@@ -238,7 +336,7 @@ kudos.post("/public-kudos-send", async (c) => {
       console.error("Error inserting kudos_moderation (non-fatal):", modErr);
     }
 
-    // ── 12) Compute remaining quota ────────────────────────────────
+    // ── 14) Compute remaining quota ────────────────────────────────
     const remainingQuota = Math.max(0, quota - (used + 1));
 
     console.log(

--- a/50_API/supabase/functions/api/routes_stays.ts
+++ b/50_API/supabase/functions/api/routes_stays.ts
@@ -1,6 +1,8 @@
 // Stay lifecycle routes: ops-checkin, ops-checkout
 import { Hono } from "npm:hono";
 import { authAndAuthorize, createServiceClient, ROUTE_PREFIX } from "./_shared.ts";
+// Blockchain: chain_receipt は Kudos 送信時点（routes_kudos_guest.ts）で作成済み。
+// checkout では kudos の confirm/reject のみ行い、chain_receipt は触らない。
 
 const stays = new Hono();
 
@@ -330,40 +332,10 @@ stays.post(`${ROUTE_PREFIX}/ops-checkout`, async (c) => {
     }
     confirmedCount = confirmedRows?.length || 0;
 
-    // 8) Create chain_receipt for confirmed kudos
-    // TODO: Blockchain — MVP queues receipts; actual on-chain anchoring is deferred.
-    // When blockchain integration is implemented:
-    //   - Compute anchor_hash = sha256(kudos_id:company_id:stay_id:receiver:category:points:created_at)
-    //   - A background job will pick up queued receipts and write to chain (e.g. Avalanche C-Chain)
-    //   - After tx confirmation, update receipt_status='confirmed' with tx_hash
-    if (confirmedRows && confirmedRows.length > 0) {
-      const receipts = confirmedRows.map((k: any) => ({
-        kudos_id: k.kudos_id,
-        chain_name: "Avalanche C-Chain",
-        anchor_hash: `TODO_sha256_${k.kudos_id}`, // TODO: Blockchain — compute real sha256 hash
-        tx_hash: null,
-        points_awarded: k.points_awarded || 0,
-        receipt_status: "queued",
-        submitted_at: null,
-        confirmed_at: null,
-        fail_reason: null,
-        version: 1,
-        created_at: now,
-        updated_at: now,
-      }));
-
-      const { data: insertedReceipts, error: receiptErr } = await supabaseSvc
-        .from("chain_receipt")
-        .upsert(receipts, { onConflict: "kudos_id", ignoreDuplicates: true })
-        .select("chain_receipt_id");
-
-      if (receiptErr) {
-        // Non-fatal: chain_receipt table may not exist in MVP seed
-        console.log("[ops-checkout] chain_receipt insert warning (non-fatal):", receiptErr.message);
-      } else {
-        queuedReceiptCount = insertedReceipts?.length || 0;
-      }
-    }
+    // 8) chain_receipt は Kudos 送信時点（/public-kudos-send）で既に queued 作成済み。
+    // checkout では kudos_status の確定のみ行う。chain_receipt は Worker が非同期で処理する。
+    // queued_receipt_count は参考値として confirmed 数をそのまま流用。
+    queuedReceiptCount = confirmedCount;
 
     // 9) Audit log
     const { error: auditErr } = await supabaseSvc


### PR DESCRIPTION
- ReceiptRegistry.sol: Avalanche Fuji 用スマートコントラクト
- chain_receipt: 送信時点で queued 作成、Worker が非同期でオンチェーン送信
- anchor_hash V2: message_text ハッシュを含めメッセージ改ざんも検知
- pg_cron: chain-worker-submit / chain-worker-confirm を毎分実行
- checkout: kudos_status の確定のみ（chain_receipt は触らない）

Made-with: Cursor