### PR TITLE
feat: AIモデレーション + クールダウン無効化

### DIFF
--- a/50_API/supabase/functions/api/moderation.ts
+++ b/50_API/supabase/functions/api/moderation.ts
@@ -1,0 +1,171 @@
+// AI コンテンツモデレーション — Kudos 投稿前のスコアリング
+// ネガティブ表現・誹謗中傷・無意味な文字列等を検出し、90点未満なら投稿を拒否する土台
+
+export interface ModerationResult {
+  /** 0〜100 のスコア（100が最も適切） */
+  score: number;
+  /** 閾値以上なら true */
+  passed: boolean;
+  /** 拒否理由（passed=false の場合） */
+  reason?: string;
+  /** 検出した問題の種別（例: negative, defamation, gibberish） */
+  flags?: string[];
+  /** 使用したモデル（デバッグ用） */
+  model?: string;
+}
+
+const DEFAULT_THRESHOLD = 90;
+
+const SYSTEM_PROMPT = `あなたはホテルスタッフへの感謝メッセージ（Kudos）の品質チェッカーです。
+以下の観点でメッセージを0〜100点でスコアリングしてください。
+
+減点対象:
+- ネガティブ表現
+- 誹謗中傷、侮辱
+- 意味のない文字の羅列（例: ああああ、test）
+- スパムや宣伝
+- 不適切な内容
+
+加点対象:
+- 具体的で誠実な感謝
+
+JSON のみで返答してください。例: {"score": 85, "reason": "やや抽象的", "flags": []}
+スコアが90未満の場合は reason と flags を必ず含めてください。`;
+
+/**
+ * 生成AIで Kudos メッセージをスコアリングする。
+ * 閾値（デフォルト90）未満なら passed=false を返し、投稿を中断する。
+ *
+ * @param messageText - 投稿内容
+ * @param threshold - 合格ライン（0〜100）
+ * @returns ModerationResult
+ */
+/** ログ用: メッセージの先頭のみ（プライバシー配慮） */
+function messagePreview(text: string, maxLen = 30): string {
+  const t = text.trim();
+  if (t.length <= maxLen) return t;
+  return t.slice(0, maxLen) + "...";
+}
+
+export async function scoreKudosContent(
+  messageText: string,
+  threshold: number = DEFAULT_THRESHOLD
+): Promise<ModerationResult> {
+  const apiKey = Deno.env.get("OPENAI_API_KEY");
+  const preview = messagePreview(messageText);
+
+  if (!apiKey) {
+    const result = fallbackScore(messageText, threshold);
+    console.log("[moderation] fallback", {
+      preview,
+      score: result.score,
+      passed: result.passed,
+      model: result.model,
+      flags: result.flags,
+    });
+    return result;
+  }
+
+  try {
+    const result = await callOpenAI(messageText, apiKey);
+    const passed = result.score >= threshold;
+    console.log("[moderation] AI", {
+      preview,
+      score: result.score,
+      threshold,
+      passed,
+      model: result.model,
+      reason: result.reason,
+      flags: result.flags,
+    });
+    return { ...result, passed };
+  } catch (err) {
+    console.error("[moderation] OpenAI API error:", err);
+    const result = fallbackScore(messageText, threshold);
+    console.log("[moderation] fallback (API error)", {
+      preview,
+      score: result.score,
+      passed: result.passed,
+      model: result.model,
+    });
+    return result;
+  }
+}
+
+async function callOpenAI(
+  messageText: string,
+  apiKey: string
+): Promise<ModerationResult> {
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: `以下のメッセージをスコアリングしてください:\n\n${messageText}` },
+      ],
+      response_format: { type: "json_object" },
+      temperature: 0.2,
+    }),
+  });
+
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`OpenAI API error: ${response.status} ${errText}`);
+  }
+
+  const data = await response.json();
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) throw new Error("No content in OpenAI response");
+
+  const parsed = JSON.parse(content) as { score?: number; reason?: string; flags?: string[] };
+  const score = Math.max(0, Math.min(100, Number(parsed.score) ?? 50));
+  return {
+    score,
+    passed: false, // 呼び出し元で threshold と比較する
+    reason: parsed.reason,
+    flags: Array.isArray(parsed.flags) ? parsed.flags : [],
+    model: "gpt-4o-mini",
+  };
+}
+
+/**
+ * API キー未設定時・API 失敗時のフォールバック。
+ * 簡易ルールでブロックし、それ以外は通過させる。
+ */
+function fallbackScore(messageText: string, threshold: number): ModerationResult {
+  const trimmed = messageText.trim();
+  const flags: string[] = [];
+
+  // 無意味な文字列の羅列（同じ文字が5回以上連続）
+  if (/^(.)\1{4,}$/.test(trimmed)) {
+    flags.push("gibberish");
+    return { score: 0, passed: false, reason: "意味のない文字の羅列は投稿できません。", flags };
+  }
+
+  // 極端に短い（1〜2文字）
+  if (trimmed.length <= 2) {
+    flags.push("too_short");
+    return { score: 0, passed: false, reason: "もう少し具体的なメッセージを入力してください。", flags };
+  }
+
+  // 明らかな不適切語（例: 簡易チェック）
+  const blockedPatterns = [
+    /死ね|殺す|消えろ/i,
+    /バカ|馬鹿|あほ|アホ/i,
+    /クソ|クソ|糞/i,
+  ];
+  for (const p of blockedPatterns) {
+    if (p.test(trimmed)) {
+      flags.push("inappropriate");
+      return { score: 0, passed: false, reason: "不適切な表現が含まれています。内容を修正してください。", flags };
+    }
+  }
+
+  // フォールバック: 通過（API 未設定時はブロックしない）
+  return { score: 100, passed: true, model: "fallback" };
+}

--- a/50_API/supabase/functions/api/routes_kudos_guest.ts
+++ b/50_API/supabase/functions/api/routes_kudos_guest.ts
@@ -5,6 +5,7 @@
 import { Hono } from "npm:hono";
 import { ethers } from "npm:ethers@6";
 import { errorResponse, validateGuestSession, createServiceClient } from "./_shared.ts";
+import { scoreKudosContent } from "./moderation.ts";
 
 const ALLOWED_ROLES = ["employee", "staff", "manager"];
 
@@ -230,14 +231,46 @@ kudos.post("/public-kudos-send", async (c) => {
       }
     }
 
-    // ── 9) Minimal moderation (MVP rule-based) ─────────────────────
+    // ── 9) AI コンテンツスコアリング（オンチェーン記録前にチェック）────────────
+    // ネガティブ表現・誹謗中傷・無意味な文字列等を検出。閾値未満なら投稿を中断。
+    const contentThreshold = (rules as any).content_score_threshold ?? 90;
+    const moderationResult = await scoreKudosContent(message_text.trim(), contentThreshold);
+
+    if (!moderationResult.passed) {
+      console.log("[public-kudos-send] moderation REJECTED", {
+        stay_id,
+        score: moderationResult.score,
+        threshold: contentThreshold,
+        reason: moderationResult.reason,
+        flags: moderationResult.flags,
+        message_preview: message_text.trim().slice(0, 30) + (message_text.length > 30 ? "..." : ""),
+      });
+      return c.json(
+        errorResponse("CONTENT_MODERATION_FAILED", "メッセージの内容が投稿基準を満たしていません。内容を修正して再度お試しください。", {
+          score: moderationResult.score,
+          threshold: contentThreshold,
+          reason: moderationResult.reason,
+          flags: moderationResult.flags,
+        }),
+        400
+      );
+    }
+
+    console.log("[public-kudos-send] moderation PASSED", {
+      stay_id,
+      score: moderationResult.score,
+      threshold: contentThreshold,
+      model: moderationResult.model,
+    });
+
+    // ── 10) Minimal moderation (MVP rule-based) ─────────────────────
     let moderationDecision = "allow";
     const lowerMsg = message_text.toLowerCase();
     if (lowerMsg.includes("http://") || lowerMsg.includes("https://")) {
       moderationDecision = "review";
     }
 
-    // ── 10) Insert kudos ───────────────────────────────────────────
+    // ── 11) Insert kudos ───────────────────────────────────────────
     const kudosStatus = moderationDecision === "block" ? "rejected" : "pending";
 
     const { data: newKudos, error: insertErr } = await db
@@ -267,7 +300,7 @@ kudos.post("/public-kudos-send", async (c) => {
       );
     }
 
-    // ── 11) オンチェーン記録キュー投入（Option B — 送信時点） ──────────
+    // ── 12) オンチェーン記録キュー投入（Option B — 送信時点） ──────────
     // anchor_hash を今この時点の DB 値から確定的に計算し、chain_receipt を queued で作成。
     // Worker（chain-worker-submit）が ~1 分以内に Avalanche C-Chain に送信する。
     // kudos_status（pending/confirmed/rejected）はチェックアウト時に DB 側で確定するが、
@@ -317,15 +350,15 @@ kudos.post("/public-kudos-send", async (c) => {
       console.error("[public-kudos-send] anchor_hash computation error (non-fatal):", hashErr);
     }
 
-    // ── 13) Insert moderation record ───────────────────────────────
+    // ── 13) Insert moderation record (AI score + rule-based) ──────────
     const { error: modErr } = await db
       .from("kudos_moderation")
       .insert({
         kudos_id: newKudos.kudos_id,
         moderation_decision: moderationDecision,
-        reason_codes: null,
-        score_json: null,
-        model_name: "mvp-rule",
+        reason_codes: moderationResult.flags?.length ? moderationResult.flags : null,
+        score_json: { ai_score: moderationResult.score, threshold: contentThreshold },
+        model_name: moderationResult.model ?? "mvp-rule",
         reviewed_by_user_id: null,
         reviewed_at: null,
         version: 1,
@@ -336,7 +369,7 @@ kudos.post("/public-kudos-send", async (c) => {
       console.error("Error inserting kudos_moderation (non-fatal):", modErr);
     }
 
-    // ── 14) Compute remaining quota ────────────────────────────────
+    // ── 14) Compute remaining quota ─────────────────────────────────
     const remainingQuota = Math.max(0, quota - (used + 1));
 
     console.log(

--- a/50_API/supabase/functions/api/routes_stays.ts
+++ b/50_API/supabase/functions/api/routes_stays.ts
@@ -126,9 +126,10 @@ stays.post(`${ROUTE_PREFIX}/ops-checkin`, async (c) => {
     // 8) Build rules_snapshot (MVP fixed values)
     const rulesSnapshot = {
       kudos_quota: 3,
-      cooldown_sec: 600,
+      cooldown_sec: 0, // 0=クールダウンなし（UI側で制御する場合は有効化）
       post_checkout_window_sec: 3600,
       points_award: 100,
+      content_score_threshold: 90, // AI モデレーション: 100点中この値以上で投稿可
     };
 
     const checkinTime = checkin_at || new Date().toISOString();


### PR DESCRIPTION
- moderation.ts: オンチェーン記録前にAIスコアリング（90点未満で拒否）
- routes_kudos_guest: スコアチェック組み込み、ログ追加
- routes_stays: cooldown_sec を 0 に（クールダウンなし）

Made-with: Cursor